### PR TITLE
Check first if there's a draw function available

### DIFF
--- a/src/lib/ImageEffectRenderer.ts
+++ b/src/lib/ImageEffectRenderer.ts
@@ -769,7 +769,10 @@ export default class ImageEffectRenderer {
     // update buffers
     for (const k in this.buffers) {
       gl.viewport(0, 0, this.width, this.height);
-      this.buffers[k].draw(this.time, this.canvas.width, this.canvas.height);
+
+      if (this.buffers[k].draw) {
+        this.buffers[k].draw(this.time, this.canvas.width, this.canvas.height);
+      }
     }
 
     gl.viewport(this.left, this.top, this.width, this.height);


### PR DESCRIPTION
On my last project we had a really weird issue where the library would fail on the client's environment (embedded app in a Drupal site).

Checking if draw is available was the only way we could solve the issue.

I'm not sure if this brings any side-effects but it seemed to work fine everywhere now.